### PR TITLE
Lighthouse: Fix output format semantics

### DIFF
--- a/Runner.rb
+++ b/Runner.rb
@@ -1,8 +1,9 @@
 class LighthouseRunner
    INTERNAL_ROOT = '/var/lighthouse'
 
-   def initialize output_format, output_directory, endpoint_name, url
+   def initialize output_format, output_format_options, output_directory, endpoint_name, url
       @output_format = output_format
+      @output_format_options = output_format_options
       @output_directory = output_directory
       @endpoint_name = endpoint_name
       @url = url
@@ -16,7 +17,7 @@ class LighthouseRunner
          -v #{absolute_output_path}:/var/lighthouse/:z \
          lighthouse \
          --chrome-flags='--headless --no-sandbox' \
-         --output #{@output_format} \
+         #{@output_format_options} \
          --output-path "#{internal_output_path}" \
          "#{@url}"
       DOCKER_RUN
@@ -27,7 +28,7 @@ class LighthouseRunner
    private
 
    def internal_output_path
-      return "#{INTERNAL_ROOT}/#{@endpoint_name}.#{@output_format}"
+      return "#{INTERNAL_ROOT}/#{@endpoint_name}#{@output_format}"
    end
 
    def absolute_output_path

--- a/run.rb
+++ b/run.rb
@@ -17,9 +17,10 @@ DOCOPT
 
 log :info, "Running Lighthouse against '#{args["<URL>"]}'"
 
-output_format = (args['--html'] ? 'html' : 'json')
+output_format_options = (args['--html'] ? '--output="html" --output="json"' : '--output "json"')
+output_format = (args['--html'] ? '' : '.json')
 output_directory = args['<output_directory>']
 endpoint_name = args['<endpoint_name>']
 url = args['<URL>']
 
-LighthouseRunner.new(output_format, output_directory, endpoint_name, url).run
+LighthouseRunner.new(output_format, output_format_options, output_directory, endpoint_name, url).run


### PR DESCRIPTION
We want to get html _and_ json output. This was not working correctly.

CC @andyg0808 

Ref: https://github.com/iFixit/ifixit/pull/29822