### PR TITLE
Add session token parameter

### DIFF
--- a/Runner.rb
+++ b/Runner.rb
@@ -20,7 +20,7 @@ class LighthouseRunner
          --chrome-flags='--headless --no-sandbox' \
          #{@output_format_options} \
          --output-path "#{internal_output_path}" \
-				 #{extra_headers} \
+             #{extra_headers} \
          "#{@url}"
       DOCKER_RUN
       log :debug, docker_run_cmd
@@ -37,11 +37,11 @@ class LighthouseRunner
       return File.expand_path(@output_directory)
    end
 
-	 def extra_headers
+   def extra_headers
       if @session_token then
-        return %Q[--extra-headers='{"Cookie": "session_4813=#{@session_token}"}']
+         return %Q[--extra-headers='{"Cookie": "session_4813=#{@session_token}"}']
       else
-        return ""
+         return ""
       end
    end
 end

--- a/Runner.rb
+++ b/Runner.rb
@@ -20,7 +20,7 @@ class LighthouseRunner
          --chrome-flags='--headless --no-sandbox' \
          #{@output_format_options} \
          --output-path "#{internal_output_path}" \
-             #{extra_headers} \
+         #{extra_headers} \
          "#{@url}"
       DOCKER_RUN
       log :debug, docker_run_cmd

--- a/Runner.rb
+++ b/Runner.rb
@@ -1,12 +1,13 @@
 class LighthouseRunner
    INTERNAL_ROOT = '/var/lighthouse'
 
-   def initialize output_format, output_format_options, output_directory, endpoint_name, url
+   def initialize output_format, output_format_options, output_directory, endpoint_name, url, session_token
       @output_format = output_format
       @output_format_options = output_format_options
       @output_directory = output_directory
       @endpoint_name = endpoint_name
       @url = url
+      @session_token = session_token
    end
 
    def run
@@ -19,6 +20,7 @@ class LighthouseRunner
          --chrome-flags='--headless --no-sandbox' \
          #{@output_format_options} \
          --output-path "#{internal_output_path}" \
+				 #{extra_headers} \
          "#{@url}"
       DOCKER_RUN
       log :debug, docker_run_cmd
@@ -33,5 +35,13 @@ class LighthouseRunner
 
    def absolute_output_path
       return File.expand_path(@output_directory)
+   end
+
+	 def extra_headers
+      if @session_token then
+        return "--extra-headers=\"{\\\"Cookie\\\": \\\"session_4813=#{@session_token}\\\"}\""
+      else
+        return ""
+      end
    end
 end

--- a/Runner.rb
+++ b/Runner.rb
@@ -39,7 +39,7 @@ class LighthouseRunner
 
 	 def extra_headers
       if @session_token then
-        return "--extra-headers=\"{\\\"Cookie\\\": \\\"session_4813=#{@session_token}\\\"}\""
+        return %Q[--extra-headers='{"Cookie": "session_4813=#{@session_token}"}']
       else
         return ""
       end

--- a/Runner.rb
+++ b/Runner.rb
@@ -1,7 +1,7 @@
 class LighthouseRunner
    INTERNAL_ROOT = '/var/lighthouse'
 
-   def initialize output_format, output_format_options, output_directory, endpoint_name, url, session_token
+   def initialize output_format, output_format_options, output_directory, endpoint_name, url, session_token = nil
       @output_format = output_format
       @output_format_options = output_format_options
       @output_directory = output_directory

--- a/run.rb
+++ b/run.rb
@@ -8,7 +8,7 @@ args = parse_args <<DOCOPT
 Lighthouse Runner
 
 Usage:
-  #{File.basename __FILE__} [--html] <output_directory> <endpoint_name> <URL>
+  #{File.basename __FILE__} [--html] <output_directory> <endpoint_name> <URL> <session_token>
 
 Options:
   --html              Generate HTML format report
@@ -22,5 +22,6 @@ output_format = (args['--html'] ? '' : '.json')
 output_directory = args['<output_directory>']
 endpoint_name = args['<endpoint_name>']
 url = args['<URL>']
+session_token = args['<session_token>']
 
-LighthouseRunner.new(output_format, output_format_options, output_directory, endpoint_name, url).run
+LighthouseRunner.new(output_format, output_format_options, output_directory, endpoint_name, url, session_token).run

--- a/run.rb
+++ b/run.rb
@@ -22,6 +22,6 @@ output_format = (args['--html'] ? '' : '.json')
 output_directory = args['<output_directory>']
 endpoint_name = args['<endpoint_name>']
 url = args['<URL>']
-session_token = args['<session_token>'] || nil
+session_token = args['<session_token>']
 
 LighthouseRunner.new(output_format, output_format_options, output_directory, endpoint_name, url, session_token).run

--- a/run.rb
+++ b/run.rb
@@ -8,7 +8,7 @@ args = parse_args <<DOCOPT
 Lighthouse Runner
 
 Usage:
-  #{File.basename __FILE__} [--html] <output_directory> <endpoint_name> <URL> <session_token>
+  #{File.basename __FILE__} [--html] <output_directory> <endpoint_name> <URL> [<session_token>]
 
 Options:
   --html              Generate HTML format report
@@ -22,6 +22,6 @@ output_format = (args['--html'] ? '' : '.json')
 output_directory = args['<output_directory>']
 endpoint_name = args['<endpoint_name>']
 url = args['<URL>']
-session_token = args['<session_token>']
+session_token = args['<session_token>'] || nil
 
 LighthouseRunner.new(output_format, output_format_options, output_directory, endpoint_name, url, session_token).run


### PR DESCRIPTION
This allows lighthouse to run on https://tweety.dozuki.com even though tweety is private.

It would probably be good to abstract out the siteid.

Other half of this project: https://github.com/iFixit/ifixit/pull/30519