### PR TITLE
Use alpine and call lighthouse effectively

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@ FROM fedora:30
 RUN dnf install -y \
     npm \
     chromium \
-    && npm install -g lighthouse \
     && mkdir -p /root/.config/configstore \
     && echo '{"isErrorReportingEnabled": false}' > /root/.config/configstore/lighthouse.json
 
 WORKDIR /opt/lighthouse
+
+RUN npm install lighthouse
+
 VOLUME /var/lighthouse
 
-ENTRYPOINT [ "/usr/bin/lighthouse" ]
+ENTRYPOINT [ "/usr/bin/npx", "lighthouse" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN npm install lighthouse \
 
 VOLUME /var/lighthouse
 
-ENTRYPOINT [ "/usr/bin/npx", "lighthouse" ]
+ENTRYPOINT [ "npx", "lighthouse" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.12
 
 WORKDIR /opt/lighthouse
 
-RUN apk update \
-    && apk add npm chromium \
+RUN apk --update-cache --no-cache \
+     add npm chromium \
     && npm install lighthouse \
     && mkdir -p /root/.config/configstore \
     && echo '{"isErrorReportingEnabled": false}' > /root/.config/configstore/lighthouse.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM alpine:3.12
 
-RUN apk update
-
-RUN apk add npm chromium
-
 WORKDIR /opt/lighthouse
 
-RUN npm install lighthouse \
+RUN apk update \
+    && apk add npm chromium \
+    && npm install lighthouse \
     && mkdir -p /root/.config/configstore \
     && echo '{"isErrorReportingEnabled": false}' > /root/.config/configstore/lighthouse.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM fedora:30
-RUN dnf install -y \
-    npm \
-    chromium \
-    && mkdir -p /root/.config/configstore \
-    && echo '{"isErrorReportingEnabled": false}' > /root/.config/configstore/lighthouse.json
+FROM alpine:3.12
+
+RUN apk update
+
+RUN apk add npm chromium
 
 WORKDIR /opt/lighthouse
 
-RUN npm install lighthouse
+RUN npm install lighthouse \
+    && mkdir -p /root/.config/configstore \
+    && echo '{"isErrorReportingEnabled": false}' > /root/.config/configstore/lighthouse.json
 
 VOLUME /var/lighthouse
 


### PR DESCRIPTION
Seems `npm install -g` might have a new location for where it installs its executables, but this fixes that situation by skipping a global install, and doing a local install instead, and then using `npx` to execute it.

This also refactors the image building process to use alpine linux which reduces the image size.

qa_req 0 ~ I tested this in dev.