### PR TITLE
Use travis ci and keep alpine up-to-date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: bash
+
+script:
+  - bash install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,5 @@ services:
 
 script:
   - docker build -t lighthouse .
-  - gem install scriptster
-
-after_script:
   - ruby run.rb . example.com http://example.com
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
-language: bash
+language: ruby
+
+services:
+  - docker
 
 script:
-  - bash install.sh
+  - docker build -t lighthouse .
+  - gem install scriptster
+
+after_script:
+  - ruby run.rb . example.com http://example.com
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
 
+os:
+  - osx
+  - linux
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 os:
-  - osx
   - linux
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ services:
   - docker
 
 script:
-  - docker build -t lighthouse .
+  - sh install.sh
   - ruby run.rb . example.com http://example.com
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:latest
 
 WORKDIR /opt/lighthouse
 


### PR DESCRIPTION
This depends on the `use-npx` branch.

Set up a Travis CI config. I turned on Travis builds for this repo. Open source for the win!

Looks like there's quite a backup right now for linux-based builds, unfortunately. From https://www.traviscistatus.com/:
![image](https://user-images.githubusercontent.com/10889879/99555648-61950280-2975-11eb-8909-e6cd6d1b4bc1.png)

qa_req 0 ~ Let's see if the build passes on Travis CI.