### PR TITLE
Use Ruby builtin `system` in place of Scriptster

### DIFF
--- a/Runner.rb
+++ b/Runner.rb
@@ -11,18 +11,18 @@ class LighthouseRunner
 
    def run
       log :info, "Saving results into: '#{absolute_output_path}'"
-      docker_run_cmd = <<~DOCKER_RUN
-         docker run \
-         --rm \
-         -v #{absolute_output_path}:/var/lighthouse/:z \
-         lighthouse \
-         --chrome-flags='--headless --no-sandbox' \
-         #{@output_format_options} \
-         --output-path "#{internal_output_path}" \
-         "#{@url}"
-      DOCKER_RUN
-      log :debug, docker_run_cmd
-      cmd docker_run_cmd, {show_out: true, out_level: :info}
+      args = [
+        'docker', 'run',
+        '--rm',
+        '-v', "#{absolute_output_path}:/var/lighthouse/:z",
+        'lighthouse',
+        "--chrome-flags='--headless --no-sandbox'",
+        *@output_format_options,
+        '--output-path', internal_output_path,
+        @url
+      ]
+      log(:info, args.join(' '))
+      system(*args)
    end
 
    private

--- a/Runner.rb
+++ b/Runner.rb
@@ -22,7 +22,7 @@ class LighthouseRunner
         @url
       ]
       log(:info, args.join(' '))
-      system(*args)
+      system(*args) or exit(70) # BSD's EX_SOFTWARE exit code
    end
 
    private

--- a/run.rb
+++ b/run.rb
@@ -17,7 +17,11 @@ DOCOPT
 
 log :info, "Running Lighthouse against '#{args["<URL>"]}'"
 
-output_format_options = (args['--html'] ? '--output="html" --output="json"' : '--output "json"')
+output_format_options = if args['--html']
+                          ['--output', 'html', '--output', 'json']
+                        else
+                          ['--output', 'json']
+                        end
 output_format = (args['--html'] ? '' : '.json')
 output_directory = args['<output_directory>']
 endpoint_name = args['<endpoint_name>']


### PR DESCRIPTION
Scriptster's `cmd` doesn't seem to support running commands with an array as the argument list. And the big benefit we seem to be getting from it is wrapping all the output lines in log lines. I think that just makes the output noisier, because Lighthouse already writes nicely-formatted log lines to stderr, which seem to also confuse Scriptster and make it show `ERR!` next to every one.

While the command was already quoted, so it was unlikely to have issues with URLs, I think cleaning up the output is worth the change.

QA:
===
You should be able to run the `run.rb` script in this repo with `./run.rb`. Pass it an output directory, an "endpoint name" (just an arbitrary name for this particular run), and a URL (e.g. `http://ifixit.com`).

The content of the output should be correct (as long as it exists!) because our script isn't actually responsible for generating the files (Lighthouse does that).

The things I think would be most important to test are 
1. Basic functionality: running the script with valid arguments results in a JSON output file ending up in the "endpoint name" directory within the output directory
1. Adding the `--html` flag results in HTML and JSON output ending up in that directory.
2. Passing an invalid URL results in the script crashing with a non-zero error code. The directory may get created; I don't really care. Whether the files get created would probably depend on Lighthouse, not us, so I don't think it's worth a lot of effort to fix.