### PR TITLE
Lighthouse configuration tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /opt/lighthouse
 
 RUN apk --update-cache --no-cache \
      add npm chromium \
-    && npm install lighthouse \
+    && npm install lighthouse@6.4.1 \
     && mkdir -p /root/.config/configstore \
     && echo '{"isErrorReportingEnabled": false}' > /root/.config/configstore/lighthouse.json
 

--- a/Runner.rb
+++ b/Runner.rb
@@ -17,6 +17,7 @@ class LighthouseRunner
         '-v', "#{absolute_output_path}:/var/lighthouse/:z",
         'lighthouse',
         "--chrome-flags='--headless --no-sandbox'",
+        "--only-categories=accessibility,best-practices,performance,seo",
         *@output_format_options,
         '--output-path', internal_output_path,
         @url


### PR DESCRIPTION
1. Disable PWA checking
   Since we're not aiming for PWA right now, this should reduce our risk of hitting Lighthouse bugs and may also speed up runs.
2. Use specific version of Lighthouse
   There seems to be a bug in the newer version which causes it to hang. See the recent comments on https://github.com/GoogleChrome/lighthouse/issues/6512. I'd rather force an older version for now that works; we can update later once it seems more stable.

qa_req 0
This code's already running.

Connects ifixit/ifixit#36110