### PR TITLE
Lighthouse: Exclude some audits

### DIFF
--- a/lighthouse-config.js
+++ b/lighthouse-config.js
@@ -1,11 +1,16 @@
 module.exports = {
-  extends: 'lighthouse:default',
+  extends: "lighthouse:default",
   settings: {
-    onlyCategories: ['performance'],
+    onlyCategories: ["performance"],
+    skipAudits: [
+      "full-page-screenshot",
+      "screenshot-thumbnails",
+      "final-screenshot",
+    ],
     maxWaitForFcp: min(1),
     maxWaitForLoad: min(2),
-  }
-}
+  },
+};
 
 function min(n) {
   return n * 60 * 1000;


### PR DESCRIPTION
These seem to be causing us problems. Lighthouse complains that it doesn't know what the `full-page-screenshot` audit is, but including it in the list here does seem to prevent it from being run (dropping it causes a `FullPageScreenshot` gather to be run). It's been squirrelly over time, and we don't use the resulting data for the Lighthouse runs we do with this container, so I'm happy to see it go.