### PR TITLE
Update Dockerfile and use the image for the Lighthouse Python script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+set -exuo pipefail
+
 docker build -t lighthouse lighthouse-docker
 
 gem install bundler
 bundle install
+
+pip install -r requirements.txt

--- a/lib/lighthouse.py
+++ b/lib/lighthouse.py
@@ -2,13 +2,33 @@ import json
 import subprocess
 
 class Lighthouse:
-    command = ['lighthouse', '--output=json', '--quiet', '--chrome-flags="--headless"']
+    IMAGE_NAME = 'lighthouse'
+
+    def __init__(self):
+        # Check if the lighthouse image is locally saved
+        result = subprocess.run(['docker', 'images', self.IMAGE_NAME], stdout=subprocess.PIPE)
+        if result.returncode != 0 or self.IMAGE_NAME not in result.stdout.decode():
+            raise Exception(f'{self.IMAGE_NAME} image not found.\nTry running: `docker build -t {self.IMAGE_NAME} ./lighthouse-docker`')
+
+        self.command = [
+            'docker', 'run',
+            '--rm',
+            '--name', 'lighthouse',
+            self.IMAGE_NAME
+        ]
+
+        self.lighthouse_options = [
+            '--output=json',
+            '--quiet',
+        ]
 
     def run(self, url):
-        command = self.command + [url]
+        command = self.command + [url] + self.lighthouse_options
         result = subprocess.run(command, stdout=subprocess.PIPE)
 
         if result.returncode != 0:
+            output = result.stdout.decode('utf-8')
+            print(output)
             raise Exception('Lighthouse failed')
 
         return json.loads(result.stdout)

--- a/lib/lighthouse.py
+++ b/lib/lighthouse.py
@@ -18,6 +18,7 @@ class Lighthouse:
         ]
 
         self.lighthouse_options = [
+            '--no-enable-error-reporting',
             '--output=json',
             '--quiet',
         ]

--- a/lighthouse-docker/Dockerfile
+++ b/lighthouse-docker/Dockerfile
@@ -1,13 +1,13 @@
-FROM alpine:20210212
+FROM node:18-slim
 
 WORKDIR /opt/lighthouse
 
-RUN apk --update-cache --no-cache \
-     add npm chromium \
-    && npm install lighthouse@8.0.0 \
-    && mkdir -p /root/.config/configstore \
-    && echo '{"isErrorReportingEnabled": false}' > /root/.config/configstore/lighthouse.json
+RUN apt-get update --fix-missing && apt-get -y upgrade \
+    && apt-get install -y chromium \
+    && npm install --global lighthouse@10.3.0 \
+    && apt-get clean
 
-VOLUME /var/lighthouse
+ENV CHROME_PATH=/usr/bin/chromium
+ENV CHROMIUM_FLAGS="--headless --no-sandbox --disable-dev-shm-usage"
 
-ENTRYPOINT [ "npx", "lighthouse" ]
+ENTRYPOINT ["lighthouse"]


### PR DESCRIPTION
## Description

In order to run `lighthouse` as part of a cron task we would have needed to install `lighthouse` and `chromium` on the machine we were planning on running it on. We already have a Dockerfile to containerize the execution of running `lighthouse` so let's just use it for the Python script as well.

That said, I did run into some problems attempting to use the image built with the previous Dockerfile so I ended up updating and tweaking the Dockerfile.

### QA

Similar to https://github.com/iFixit/lighthouse-docker/pull/14
1. Have `docker` installed and running
2. Run `./install.sh`
3. Run `python3 lib/main.py` and confirm that lighthouse was run for each URL and the metrics show up in DataDog

Connects: https://github.com/iFixit/ifixit/issues/48363