### PR TITLE
Lighthouse Docker: Use fedora 32 compatible docker image

### DIFF
--- a/lighthouse-docker/Dockerfile
+++ b/lighthouse-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-slim
+FROM node:18-bullseye-slim
 
 WORKDIR /opt/lighthouse
 


### PR DESCRIPTION
## Description

`node:18-slim` was having issues running on a Fedora 32 host, which is what we use on Ubreakit. This change switches to a bullseye-based image which is compatible with Fedora 32.

### QA

Run `apt-get update` on a `node:18-bullseye-slime` container and verify it worked on Ubreakit.



