### PR TITLE
Abstract Logic for urls lighthouse-docker audits

### DIFF
--- a/urls.example.json
+++ b/urls.example.json
@@ -1,0 +1,3 @@
+{
+    "Page Type": ["https://example.com/"]
+}


### PR DESCRIPTION
## Description

This moves the urls to a json file with a particular structure, as stated in the urls.example.json file. This will allow us to easily configure the urls we want to audit and easily tag them when sending them to DataDog.

### CR

I chose to move the urls to a `json` file so it would make it easier to modify if the current list selected from minerva.ifixit.com would not be suitable for addressing https://github.com/iFixit/ifixit/issues/48916

### QA 

- [ ] Confirm `lighthouse-docker` audits the list of urls in `urls.json` and sends them to DataDog with the `page_type` value of the key.

Connects: https://github.com/iFixit/ifixit/issues/48916