### PR TITLE
Add Config to Retrieve Metrics from Reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 __pycache__
+urls.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 __pycache__
 urls.json
+metrics-config.json

--- a/lib/main.py
+++ b/lib/main.py
@@ -14,11 +14,7 @@ def retrieve_values_for_audits(json_results, audits):
 def get_audits_value(json_results, audit_name):
     return json_results.get('audits').get(audit_name).get('numericValue') or 0
 
-def send_metrics_to_datadog(page_type, url, metrics):
-    tags = {
-        'page_type': page_type,
-        'url': url,
-    }
+def send_metrics_to_datadog(metrics, tags={}):
     tags = [f'{k}:{v}' for k, v in tags.items()]
 
     dd_client = DataDogApiClient()
@@ -48,7 +44,7 @@ def main():
                 metrics = retrieve_values_for_audits(json_results, audits)
 
                 print(f'Sending metrics to datadog for {url}')
-                send_metrics_to_datadog(page_type, url, metrics)
+                send_metrics_to_datadog(metrics, tags = {'url': url, 'page_type': page_type})
 
                 print(f'Finished sending metrics to datadog for {url}\n')
 

--- a/lib/main.py
+++ b/lib/main.py
@@ -44,7 +44,11 @@ def main():
                 metrics = retrieve_values_for_audits(json_results, audits)
 
                 print(f'Sending metrics to datadog for {url}')
-                send_metrics_to_datadog(metrics, tags = {'url': url, 'page_type': page_type})
+                send_metrics_to_datadog(metrics, tags = {
+                    'url': url,
+                    'page_type': page_type,
+                    'lighthouse_version': json_results.get('lighthouseVersion'),
+                })
 
                 print(f'Finished sending metrics to datadog for {url}\n')
 

--- a/lib/main.py
+++ b/lib/main.py
@@ -5,25 +5,11 @@ from urllib.parse import urlparse
 from dotenv import load_dotenv
 load_dotenv()
 
-def parse_json_report(json_results):
-    # Cumulative Layout Shift
-    cumulative_layout_shift = get_audits_value(json_results, 'cumulative-layout-shift')
-
-    # Largest Contentful Paint
-    largest_contentful_paint = get_audits_value(json_results, 'largest-contentful-paint')
-
-    # Total Blocking Time
-    total_blocking_time = get_audits_value(json_results, 'total-blocking-time')
-
-    # Network Request Total Transfer Size
-    page_size = json_results.get('audits').get('diagnostics').get('details').get('items')[0].get('totalByteWeight')
-
-    return {
-        'cumulative_layout_shift': cumulative_layout_shift,
-        'largest_contentful_paint': largest_contentful_paint,
-        'total_blocking_time': total_blocking_time,
-        'page_size': page_size
-    }
+def retrieve_values_for_audits(json_results, audits):
+   metrics = {}
+   for audit in audits:
+        metrics[audit] = get_audits_value(json_results, audit)
+   return metrics
 
 def get_audits_value(json_results, audit_name):
     return json_results.get('audits').get(audit_name).get('numericValue') or 0
@@ -45,6 +31,10 @@ def main():
     with open('urls.json') as f:
         urls = json.load(f)
 
+    with open('metrics-config.json') as f:
+        metrics_config = json.load(f)
+        audits = metrics_config.get('audits')
+
     for page_type, url_list in urls.items():
         print(f'Running Lighthouse for {page_type} pages\n')
 
@@ -55,7 +45,7 @@ def main():
                 print(f'Finished running lighthouse for {url}\n')
 
                 print(f'Parsing lighthouse results for {url}\n')
-                metrics = parse_json_report(json_results)
+                metrics = retrieve_values_for_audits(json_results, audits)
 
                 print(f'Sending metrics to datadog for {url}')
                 send_metrics_to_datadog(page_type, url, metrics)

--- a/metrics-config.example.json
+++ b/metrics-config.example.json
@@ -1,0 +1,3 @@
+{
+    "audits": [] // array of audits to scrape from lighthouse reports
+}


### PR DESCRIPTION
## Description

To address https://github.com/iFixit/ifixit/issues/48917 it will be easier if we create a configuration file that defines which metrics we want to retrieve from the Lighthouse reports and to send to DataDog.

### CR

This will be similar to #18 where we will create a `metrics-config.json` in `server-templates`. 

### QA

1. Clone this repo
2. Run `cp .env.template .env`
3. Retrieve the values from `/etc/dozuki/datadog-api.json`
4. Run `cp urls.example.json urls.json`
5. Set a single test page and url
6. Run `cp metrics-config.example.json cp metrics-config.json`
7. Paste the following
```json
{
    "audits": [
        "largest-contentful-paint",
        "first-contentful-paint",
        "cumulative-layout-shift",
        "total-blocking-time",
        "speed-index",
        "total-byte-weight",
        "server-response-time"
    ]
}
```
8. Run `python3 lib/main.py`
- [ ] Confirm metrics are sent to DataDog and are tagged with the lighthouse version now as well.

Connects: https://github.com/iFixit/ifixit/issues/48917