### PR TITLE
Fix: Resolving config file paths

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -1,4 +1,4 @@
-import json
+import json, os
 from lighthouse import Lighthouse
 from datadog_api import DataDogApiClient
 from urllib.parse import urlparse
@@ -49,10 +49,15 @@ def capture_lighthouse_metrics(page_type, url, audits, lighthouse_options=[]):
     print('=' * 80)
 
 def main():
-    with open('urls.json') as f:
+    scripts_path = os.path.abspath(__file__)
+    project_root = os.path.dirname(os.path.dirname(scripts_path))
+
+    urls_path = os.path.join(project_root, 'urls.json')
+    with open(urls_path) as f:
         urls = json.load(f)
 
-    with open('metrics-config.json') as f:
+    metrics_config_path = os.path.join(project_root, 'metrics-config.json')
+    with open(metrics_config_path) as f:
         metrics_config = json.load(f)
         audits = metrics_config.get('audits')
 


### PR DESCRIPTION
## Description

The config file path was not being resolved correctly when we were running the script through a cron task. This should now be fixed.

![image](https://github.com/iFixit/lighthouse-docker/assets/22064420/4441b150-8050-4bbd-b67b-1834da13a871)

qa_req 0 I manually modified the cron task to run sooner than every hour and applied the changes to the `/opt/lighthouse` directory. I confirmed the metrics were sent to DataDog from the cron task run.

![image](https://github.com/iFixit/lighthouse-docker/assets/22064420/b6bddda7-0537-4350-aaf1-a4d082bace10)


Connects: https://github.com/iFixit/ifixit/issues/48915