### PR TITLE
Feature: Retrieve and Send Audit Scores to DataDog

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -8,19 +8,23 @@ load_dotenv()
 def retrieve_values_for_audits(json_results, audits):
    metrics = {}
    for audit in audits:
-        metrics[audit] = get_audits_value(json_results, audit)
+        metrics[audit] = [get_audits_value(json_results, audit), get_audits_score(json_results, audit)]
    return metrics
 
 def get_audits_value(json_results, audit_name):
     return json_results.get('audits').get(audit_name).get('numericValue') or 0
+
+def get_audits_score(json_results, audit_name):
+    return json_results.get('audits').get(audit_name).get('score') or 0
 
 def send_metrics_to_datadog(metrics, tags={}):
     tags = [f'{k}:{v}' for k, v in tags.items()]
 
     dd_client = DataDogApiClient()
 
-    for metric_name, value in metrics.items():
-        dd_client.submit_metric(f'lighthouse.{metric_name}', value, tags)
+    for metric_name, [value, score] in metrics.items():
+        dd_client.submit_metric(f'lighthouse.{metric_name}.value', value, tags)
+        dd_client.submit_metric(f'lighthouse.{metric_name}.score', score , tags)
 
 def capture_lighthouse_metrics(page_type, url, audits, lighthouse_options=[]):
     lighthouse = Lighthouse()


### PR DESCRIPTION
## Description

There are audits that do not contain a `numericValue` property but do contain a `score` property. If we also want to monitor these metrics, we will need to retrieve the `score` property and send it to DataDog.

That said, we will differentiate between the `numericValue` and `score` data by subsetting the metric names with the metric type. For example instead of just `lighthouse.largest_contentful_paint` we will have `lighthouse.largest_contentful_paint.score` and `lighthouse.largest_contentful_paint.value`. 

### QA

- [ ] Confirm we are now sending `value` and `score` metrics to DataDog.
1. Have `docker` installed
2. Run `./install.sh`
3. Run `cp metrics-config.example.json metrics-config.json`
4. Copy the contents of https://github.com/iFixit/server-templates/blob/master/ansible/roles/lighthouse_docker/files/metrics-config.json into `metrics-config.json`
5. Run `cp urls.example.json urls.json`
6. Add the content to `urls.json`
```
{
    "Test": ["https://google.com/"]
}
```
7. Copy the `.env` file from `/opt/lighthouse-docker` on `ubreakit` 
8. Run `python3 lib/main.py`


Closes: https://github.com/iFixit/ifixit/issues/49344